### PR TITLE
feat: Add site configuration for GitHub Pages in astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import starlight from "@astrojs/starlight";
 // https://astro.build/config
 export default defineConfig({
   base: "ascii-progress-bar",
+  site: 'https://yacosta738.github.io',
   image: {
     service: passthroughImageService()
   },


### PR DESCRIPTION
This pull request includes a small change to the `astro.config.mjs` file. The change adds the `site` property to the configuration with the URL 'https://yacosta738.github.io'.