### PR TITLE
fix: update links.yml workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,45 +1,37 @@
 name: Links
 
-on:
-  repository_dispatch:
-  workflow_dispatch:
-  schedule:
-    - cron: '00 18 * * *'
+on: [push, pull_request]
 
 jobs:
-  linkChecker:
+  check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - name: Restore lychee cache
-        id: restore-cache
-        uses: actions/cache/restore@v4
+      - name: Cache lychee
+        id: cache-lychee
+        uses: actions/cache@v2
         with:
           path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
+          key: cache-lychee-${{ hashFiles('**/*') }}
+          restore-keys: |
+            cache-lychee-
 
-      - name: Run lychee
-        id: run-lychee
+      - name: Run lychee link checker
         uses: lycheeverse/lychee-action@v2.2.0
         with:
-          args: "--base . --cache --max-cache-age 1d . --max-redirects 10 --max-retries 5 --user-agent Chrome/51.0.2704.103 Safari/537.36"
+          args: --base . --cache --max-cache-age 1d . --max-redirects 10 --max-retries 5 --user-agent Chrome/51.0.2704.103 Safari/537.36
+          format: markdown
+          jobSummary: true
+          output: lychee/out.md
+          fail: true
+          failIfEmpty: true
+          debug: false
 
-      - name: Set lychee exit code
-        run: echo "lychee_exit_code=$?" >> $GITHUB_ENV
-
-      - name: Save lychee cache
-        uses: actions/cache/save@v4
+      - name: Upload lychee output
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          path: .lycheecache
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
-
-      - name: Create Issue From File
-        if: steps.run-lychee.outcome == 'failure'
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: Link Checker Report
-          content-filepath: ./lychee/out.md
-          labels: report, automated issue
+          name: lychee-output
+          path: lychee/out.md

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache lychee
         id: cache-lychee


### PR DESCRIPTION
This pull request modifies the `.github/workflows/links.yml` file to update the GitHub Actions workflow for checking links. The changes simplify the workflow triggers, update the job and step names, and improve the caching and output handling for the link checker.

Workflow updates:

* Changed the workflow triggers to run on `push` and `pull_request` events instead of `repository_dispatch`, `workflow_dispatch`, and a scheduled cron job.
* Renamed the job from `linkChecker` to `check-links` and updated the step names for clarity.

Caching and output improvements:

* Updated the caching step to use `actions/cache@v2` and changed the cache key to use `hashFiles('**/*')` for better cache management.
* Added new parameters to the lychee link checker step, including `format`, `jobSummary`, `output`, `fail`, `failIfEmpty`, and `debug`, to enhance the output and control over the link checking process.
* Replaced the manual cache saving and issue creation steps with an artifact upload step using `actions/upload-artifact@v2` to store the lychee output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for link checking
	- Simplified workflow triggers to enhance clarity
	- Improved caching mechanism and output handling for the link checker
	- Enhanced job naming for better understanding of workflow steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->