### PR TITLE
chore: Update publish-package.yml

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -10,6 +10,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  PBOT_GITHUB_TOKEN: ${{ secrets.PBOT_GITHUB_TOKEN }}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,6 +22,12 @@ jobs:
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/node
+
+      - name: 🔍 PBOT_GITHUB_TOKEN
+        if: env.PBOT_GITHUB_TOKEN == ''
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "PBOT_GITHUB_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
@@ -37,6 +46,6 @@ jobs:
       - name: Semantic Release
         working-directory: packages/ascii-progress-bar
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.PBOT_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for publishing the package. The updates primarily focus on the handling of the `PBOT_GITHUB_TOKEN` environment variable.

Changes to environment variables and job steps:

* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201R13-R15): Added `PBOT_GITHUB_TOKEN` to the environment variables section.
* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201R26-R31): Introduced a step to set `PBOT_GITHUB_TOKEN` using the `GITHUB_TOKEN` secret if `PBOT_GITHUB_TOKEN` is not already set.
* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201L40-R49): Updated the `Semantic Release` step to use `PBOT_GITHUB_TOKEN` instead of `GITHUB_TOKEN` directly.Add pbot token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to improve token management for package publishing
	- Enhanced security by conditionally setting GitHub authentication token

<!-- end of auto-generated comment: release notes by coderabbit.ai -->