### PR TITLE
fix(ci): add --root flag to lychee for root-relative link resolution

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,7 +30,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: "--config lychee.toml --cache --max-cache-age 1d ."
+          args: "--root . --config lychee.toml --cache --max-cache-age 1d ."
           fail: true
 
       - name: Create Issue From File


### PR DESCRIPTION
## Summary

Fixes the `InvalidPathToUri` error that occurs when lychee link checker encounters root-relative links.

## Problem

The Link Checking Workflow was failing with errors like:


This blocked multiple Dependabot/Renovate PRs.

## Solution

Added `--root .` to the lychee-action arguments so it can properly resolve root-relative URLs.

## Testing

- [x] Workflow syntax is valid
- [x] Branch pushed successfully
- [ ] CI passes (will be verified on this PR)

## Related Issues

- Fixes #85